### PR TITLE
Minor edits

### DIFF
--- a/src/2018/index.md
+++ b/src/2018/index.md
@@ -1,6 +1,6 @@
 # Rust 2018
 
-The edition system was created to create Rust 2018. The theme of Rust 2018
+The edition system was created for the release of Rust 2018. The theme of Rust 2018
 is *productivity*. Rust 2018 improves upon Rust 2015 through new features,
 simpler syntax in some cases, a smarter borrow-checker, and a host of other things.
 These are all in service of the productivity goal. Rust 2015 was a foundation;

--- a/src/2018/transitioning/traits/impl-trait.md
+++ b/src/2018/transitioning/traits/impl-trait.md
@@ -1,6 +1,6 @@
 # impl Trait
 
-`impl Trait` is new syntax that currently works in function signatures.
+`impl Trait` is the new way to specify unnamed but concrete types that implement a specific trait.
 There are two places you can put it: argument position, and return position.
 
 ```rust,ignore


### PR DESCRIPTION
The first is just removing the double use of "create". The second is opening the `impl Trait` section by saying what it is, not where it can appear.