### PR TITLE
Dedup the Rust 2018 module system quote

### DIFF
--- a/src/2018/transitioning/modules/index.md
+++ b/src/2018/transitioning/modules/index.md
@@ -1,13 +1,7 @@
 # Module system
 
 The module system is one of the most confusing aspects of Rust 2015 for many
-Rustaceans. Rust 2018 includes an overhaul of the module system. In the
-words of the core team:
-
-> In other words, while there are simple and consistent rules defining the
-module system, their consequences can feel inconsistent, counterintuitive and
-mysterious.
-
-Rust 2018's module system also consists of simple rules, but they fit
+Rustaceans. Rust 2018 includes an overhaul of the module system
+consisting of simple rules, that fit
 together in a much nicer way. We expect these changes to be one of the
 favorites in this edition.


### PR DESCRIPTION
The quote "while there are simple and consistent rules.." is also
present in the section about "Path clarity" (modules/path-clarity.md)
and fits nicely there.  So I've rephrased the lead in without it.