### PR TITLE
Lifetime section edits

### DIFF
--- a/src/2018/transitioning/ownership-and-lifetimes/anonymous-lifetime.md
+++ b/src/2018/transitioning/ownership-and-lifetimes/anonymous-lifetime.md
@@ -1,9 +1,9 @@
 # `'_`, the anonymous lifetime
 
-As of [1.26][], the "anonymous lifetime" feature, allows you to explicitly
-mark where a lifetime is elided. To do this, you can use the special lifetime
-`'_` much like you can explicitly mark that a type is inferred with the syntax
-`let x: _ = ..;`.
+Rust 2018 allows you to explicitly mark where a lifetime is elided, for types
+where this elision might otherwise be unclar. To do this, you can use the
+special lifetime `'_` much like you can explicitly mark that a type is inferred
+with the syntax `let x: _ = ..;`.
 
 [1.26]: https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1260-2018-05-10
 
@@ -13,9 +13,11 @@ Let's say, for whatever reason, that we have a simple wrapper around `&'a str`:
 struct StrWrap<'a>(&'a str);
 ```
 
-In edition 2015, you might have written:
+In Rust 2015, you might have written:
 
 ```rust
+// Rust 2015
+
 use std::fmt;
 
 # struct StrWrap<'a>(&'a str);
@@ -31,9 +33,11 @@ impl<'a> fmt::Debug for StrWrap<'a> {
 }
 ```
 
-In edition 2018, you can instead write:
+In Rust 2018, you can instead write:
 
 ```rust
+// Rust 2018
+
 #![feature(rust_2018_preview)]
 
 # use std::fmt;
@@ -52,13 +56,12 @@ impl fmt::Debug for StrWrap<'_> {
 
 ## More details
 
-In the second snippet above, we've used `-> StrWrap`.
-However, unless you take a look at the definition of `StrWrap`,
-it is not clear that the returned value is actually borrowing something.
-Therefore, starting with edition 2018, it is deprecated, for non-reference-types
-(types other than `&` and `&mut`), to leave off the lifetime parameters.
-Instead, where you previously wrote `-> StrWrap`,
-you should now, in edition 2018, write `-> StrWrap<'_>`.
+In the Rust 2015 snippet above, we've used `-> StrWrap`. However, unless you take
+a look at the definition of `StrWrap`, it is not clear that the returned value
+is actually borrowing something. Therefore, starting with Rust 2018, it is
+deprecated to leave off the lifetime parameters for non-reference-types (types
+other than `&` and `&mut`). Instead, where you previously wrote `-> StrWrap`,
+you should now write `-> StrWrap<'_>`, making clear that borrowing is occurring.
 
 What exactly does `'_` mean? It depends on the context!
 In output contexts, as in the return type of `make_wrapper`,
@@ -67,6 +70,8 @@ In input contexts, a fresh lifetime is generated for each "input location".
 More concretely, to understand input contexts, consider the following example:
 
 ```rust
+// Rust 2015
+
 struct Foo<'a, 'b: 'a> {
     field: &'a &'b str,
 }
@@ -79,6 +84,8 @@ impl<'a, 'b: 'a> Foo<'a, 'b> {
 We can rewrite this as:
 
 ```rust
+// Rust 2018
+
 #![feature(rust_2018_preview)]
 
 # struct Foo<'a, 'b: 'a> {

--- a/src/2018/transitioning/ownership-and-lifetimes/anonymous-lifetime.md
+++ b/src/2018/transitioning/ownership-and-lifetimes/anonymous-lifetime.md
@@ -1,11 +1,9 @@
 # `'_`, the anonymous lifetime
 
 Rust 2018 allows you to explicitly mark where a lifetime is elided, for types
-where this elision might otherwise be unclar. To do this, you can use the
+where this elision might otherwise be unclear. To do this, you can use the
 special lifetime `'_` much like you can explicitly mark that a type is inferred
 with the syntax `let x: _ = ..;`.
-
-[1.26]: https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1260-2018-05-10
 
 Let's say, for whatever reason, that we have a simple wrapper around `&'a str`:
 
@@ -36,12 +34,12 @@ impl<'a> fmt::Debug for StrWrap<'a> {
 In Rust 2018, you can instead write:
 
 ```rust
-// Rust 2018
-
 #![feature(rust_2018_preview)]
 
 # use std::fmt;
 # struct StrWrap<'a>(&'a str);
+
+// Rust 2018
 
 fn make_wrapper(string: &str) -> StrWrap<'_> {
     StrWrap(string)
@@ -84,13 +82,13 @@ impl<'a, 'b: 'a> Foo<'a, 'b> {
 We can rewrite this as:
 
 ```rust
-// Rust 2018
-
 #![feature(rust_2018_preview)]
 
 # struct Foo<'a, 'b: 'a> {
 #     field: &'a &'b str,
 # }
+
+// Rust 2018
 
 impl Foo<'_, '_> {
     // some methods...

--- a/src/2018/transitioning/ownership-and-lifetimes/default-match-bindings.md
+++ b/src/2018/transitioning/ownership-and-lifetimes/default-match-bindings.md
@@ -12,9 +12,11 @@ match s {
 };
 ```
 
-In older Rusts, this would fail to compile, you would have had to write this:
+In Rust 2015, this would fail to compile, you would have had to write this:
 
 ```rust,ignore
+// Rust 2015
+
 let s: &Option<&str> = Some("hello");
 
 match s {
@@ -23,19 +25,31 @@ match s {
 };
 ```
 
-As of [1.26](nicer-match-bindings), Rust will infer the `&`s and `ref`s, and your original code will Just Work.
+Rust 2018, by contrast, will infer the `&`s and `ref`s, and your original code will Just Work.
 
 [nicer-match-bindings]: https://blog.rust-lang.org/2018/05/10/Rust-1.26.html#nicer-match-bindings
 
 ## More details
 
-The mental model of `match` has shifted a bit with this change; `match s` now have
-a "default binding mode". This mode is one of `move`, `ref`, or `ref mut`. Before
-this was implemented, `match` was always in `move` mode, that is, by default it would
-assume that anything was moved when referred to, and you added `&` and `ref` to
-change that.
+The mental model of `match` has shifted a bit with this change, to bring it into
+line with other aspects of the language. For example, when writing a `for` loop,
+you can iterate over borrowed contents of a collection by borrowing the collection
+itself:
 
-Now, it can default to one of the three modes. So above, since `s` is a reference,
-the compiler assumes that the names should be bound by reference, rather than by moving.
-Similarly, if it was a mutable reference, it would be assumed that things were bound
-by mutable reference.
+```rust,ignore
+let my_vec: Vec<i32> = vec![0, 1, 2];
+
+for x in &my_vec { ... }
+```
+
+The idea is that an `&T` can be understood as a *borrowed view of `T`*, and so
+when you iterate, match, or otherwise destructure a `&T` you get a borrowed view
+of its internals as well.
+
+More formally, `match` has a "binding mode", which is one of `move`, `ref`, or
+`ref mut`. In Rust 2015, `match` always started in `move` mode, and required you
+to explicitly write `ref` or `ref mut` in patterns to switched to a borrowing
+mode. In Rust 2018, the type of the value being matched informs the binding
+mode, so that if you match against an `&Option<&str>` with a `Some` variant, you
+are put into `ref` mode automatically, giving you a borrowed view of the
+internal data. Similarly, `&mut Option<&str>` would give you a `ref mut` view.

--- a/src/2018/transitioning/ownership-and-lifetimes/default-match-bindings.md
+++ b/src/2018/transitioning/ownership-and-lifetimes/default-match-bindings.md
@@ -27,8 +27,6 @@ match s {
 
 Rust 2018, by contrast, will infer the `&`s and `ref`s, and your original code will Just Work.
 
-[nicer-match-bindings]: https://blog.rust-lang.org/2018/05/10/Rust-1.26.html#nicer-match-bindings
-
 ## More details
 
 The mental model of `match` has shifted a bit with this change, to bring it into

--- a/src/2018/transitioning/ownership-and-lifetimes/in-band-lifetimes.md
+++ b/src/2018/transitioning/ownership-and-lifetimes/in-band-lifetimes.md
@@ -1,6 +1,6 @@
 # In-band lifetimes
 
-When writing a fn declaration, if a lifetime appears that is not already in
+When writing an `fn` declaration, if a lifetime appears that is not already in
 scope, it is taken to be a new binding, i.e. treated as a parameter to the
 function.
 
@@ -13,40 +13,8 @@ fn two_args<'b>(arg1: &Foo, arg2: &'b Bar) -> &'b Baz
 In Rust 2018, you'd write:
 
 ```rust,ignore
-fn two_args(arg1: &Foo, arg2: &Bar) -> &'arg2 Baz
+fn two_args(arg1: &Foo, arg2: &'b Bar) -> &'b Baz
 ```
 
-Here, `'arg2` was not defined. Rust sees that you have a parameter, `arg2`, that
-should have a lifetime, and so the lifetime of that reference.
-
-To put it in words, the former says:
-
-> `two_args` is a function with one lifetime, `'b`. Its first parameter is a
-> reference to a `Foo`, , and its second parameter is a reference to a `Bar`,
-> bound by the lifetime `'b`, as its second argument. It returns a reference to
-> a `Baz` bound by the lifetime `'b`.
-
-And the latter says:
-
-> `two_args` is a function. Its first parameter is a reference to a `Foo`,
-> and its second parameter is a reference to a `Bar`. It returns a reference to
-> a `Baz` with the same lifetime as the second parameter.
-
-This says what it means, as opposed to implying it. Instead of defining a
-lifetime, and then connecting things together, you say "this is the lifetime
-of that."
-
-## More details
-
-More complicated signatures work too:
-
-```rust,ignore
-// before
-fn two_lifetimes<'a, 'b: 'a>(arg1: &'a Foo, arg2: &'b Bar) -> &'a Quux<'b>
-
-// after
-fn two_lifetimes(arg1: &Foo, arg2: &Bar) -> &'arg1 Quux<'arg2>
-```
-
-Here, the `'b: 'a` is inferred, as it's the only possible way that `'arg1`
-and `'arg2` could relate.
+In other words, you can drop the explicit lifetime parameter declaration, and
+instead simply start using a new lifetime name to connect lifetimes together.

--- a/src/2018/transitioning/ownership-and-lifetimes/in-band-lifetimes.md
+++ b/src/2018/transitioning/ownership-and-lifetimes/in-band-lifetimes.md
@@ -7,13 +7,13 @@ function.
 So, in Rust 2015, you'd write:
 
 ```rust,ignore
-fn two_args<'b>(arg1: &Foo, arg2: &'b Bar) -> &'b Baz
+fn two_args<'bar>(foo: &Foo, bar: &'bar Bar) -> &'bar Baz
 ```
 
 In Rust 2018, you'd write:
 
 ```rust,ignore
-fn two_args(arg1: &Foo, arg2: &'b Bar) -> &'b Baz
+fn two_args(foo: &Foo, bar: &'bar Bar) -> &'bar Baz
 ```
 
 In other words, you can drop the explicit lifetime parameter declaration, and

--- a/src/2018/transitioning/ownership-and-lifetimes/lifetime-elision-in-impl.md
+++ b/src/2018/transitioning/ownership-and-lifetimes/lifetime-elision-in-impl.md
@@ -24,6 +24,8 @@ impl SomeTrait<'tcx, 'gcx> for SomeType<'tcx, 'gcx> { ... }
 To show off how this combines with in-band lifetimes in methods/functions, in Rust 2015:
 
 ```rust,ignore
+// Rust 2015
+
 impl<'a> MyStruct<'a> {
     fn foo(&self) -> &'a str
 
@@ -36,6 +38,8 @@ impl<'a> MyStruct<'a> {
 in Rust 2018:
 
 ```rust,ignore
+// Rust 2018
+
 // no need for the repetition of 'a
 impl MyStruct<'a> {
 

--- a/src/2018/transitioning/ownership-and-lifetimes/struct-inference.md
+++ b/src/2018/transitioning/ownership-and-lifetimes/struct-inference.md
@@ -9,9 +9,11 @@ programs is by removing the need to explicitly annotate these `T: 'a` outlives
 requirements in `struct` definitions. Instead, the requirements will be
 inferred from the fields present in the definitions.
 
-Consider the following `struct` definitions which you wrote in edition 2015:
+Consider the following `struct` definitions in Rust 2015:
 
 ```rust
+// Rust 2015
+
 struct Ref<'a, T: 'a> {
     field: &'a T
 }
@@ -38,9 +40,11 @@ where
 }
 ```
 
-In edition 2018, since the requirements are inferred, you can instead write:
+In Rust 2018, since the requirements are inferred, you can instead write:
 
 ```rust,ignore
+// Rust 2018
+
 struct Ref<'a, T> {
     field: &'a T
 }


### PR DESCRIPTION
A few changes here:

- Rewrote the in-band lifetime section, which was incorrect (seemed to be based on the initial RFC rather than what was actually merged/implemented)

- Removed references to particular compiler versions. I intend to send a separate PR introducing a table of all the 2018 features, their stabilization status, and links to tracking issues where appropriate.

- Assorted minor tweaks/consistency issues.

I didn't touch slice patterns yet, because I think it should be moved to a separate section (it's not particularly connected to ownership or lifetimes).