### PR TITLE
Update lifetime-elision-in-impl.md

### DIFF
--- a/src/2018/transitioning/ownership-and-lifetimes/lifetime-elision-in-impl.md
+++ b/src/2018/transitioning/ownership-and-lifetimes/lifetime-elision-in-impl.md
@@ -46,7 +46,7 @@ impl MyStruct<'a> {
     // this works just like before
     fn foo(&self) -> &'a str
 
-    // we can refer to 'arg, rather than conflicting with 'a
-    fn bar(&self, arg: &str) -> &'arg str
+    // we can declare 'b inline here
+    fn bar(&self, arg: &'b str) -> &'b str
 }
 ```


### PR DESCRIPTION
Fix inconsistency with feature as implemented, in-band lifetimes need to be declared in the arguments and can't be implicit backreferences.

Fixes #37 