### PR TITLE
Is `'arg'` missing in Rust 2018 example?

### DIFF
--- a/src/2018/transitioning/ownership-and-lifetimes/lifetime-elision-in-impl.md
+++ b/src/2018/transitioning/ownership-and-lifetimes/lifetime-elision-in-impl.md
@@ -47,6 +47,6 @@ impl MyStruct<'a> {
     fn foo(&self) -> &'a str
 
     // we can refer to 'arg, rather than conflicting with 'a
-    fn bar(&self, arg: &str) -> &'arg str
+    fn bar(&self, arg: &'arg str) -> &'arg str
 }
 ```


### PR DESCRIPTION
It looks to me like Rust 2018 example is missing `'arg` in `arg: &str`.

OTOH, if the code is correct, then I'm misunderstanding how this is supposed to work which probably means it needs some clarification.