### PR TITLE
Update lifetime-elision-in-impl.md

### DIFF
--- a/src/2018/transitioning/ownership-and-lifetimes/lifetime-elision-in-impl.md
+++ b/src/2018/transitioning/ownership-and-lifetimes/lifetime-elision-in-impl.md
@@ -16,7 +16,7 @@ In Rust 2018:
 
 ```rust,ignore
 impl Iterator for MyIter<'iter> { ... }
-impl SomeTrait<'tcx, 'gcx> for SomeType<'tcx, 'gcx> { ... }
+impl SomeTrait<'tcx> for SomeType<'tcx, 'gcx> { ... }
 ```
 
 ## More details


### PR DESCRIPTION
An extra lifetime parameter was present; the Rust 2015 version has `SomeTrait` only taking one lifetime parameter.