### PR TITLE
Fix broken link

### DIFF
--- a/src/2018/status.md
+++ b/src/2018/status.md
@@ -5,26 +5,26 @@
 [Shipped, 1.26]: https://blog.rust-lang.org/2018/05/10/Rust-1.26.html
 [Shipped, 1.27]: https://blog.rust-lang.org/2018/06/21/Rust-1.27.html
 
-[`impl Trait`]: https://rust-lang-nursery.github.io/edition-guide/2018/transitioning/traits/impl-trait.html
-[Basic slice patterns]: https://rust-lang-nursery.github.io/edition-guide/2018/transitioning/slice-patterns.html
-[Default match bindings]: https://rust-lang-nursery.github.io/edition-guide/2018/transitioning/ownership-and-lifetimes/default-match-bindings.html
-[Anonymous lifetimes]: https://rust-lang-nursery.github.io/edition-guide/2018/transitioning/ownership-and-lifetimes/anonymous-lifetime.html
+[`impl Trait`]: 2018/transitioning/traits/impl-trait.html
+[Basic slice patterns]: 2018/transitioning/slice-patterns.html
+[Default match bindings]: 2018/transitioning/ownership-and-lifetimes/default-match-bindings.html
+[Anonymous lifetimes]: 2018/transitioning/ownership-and-lifetimes/anonymous-lifetime.html
 [relnotes_1.26]: https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1260-2018-05-10
-[`dyn Trait`]: https://rust-lang-nursery.github.io/edition-guide/2018/transitioning/traits/dyn-trait.html
-[`?` in `main`/tests]: https://rust-lang-nursery.github.io/edition-guide/2018/transitioning/errors/question-mark.html
-[Module system path changes]: https://rust-lang-nursery.github.io/edition-guide/2018/transitioning/modules/path-clarity.html
+[`dyn Trait`]: 2018/transitioning/traits/dyn-trait.html
+[`?` in `main`/tests]: 2018/transitioning/errors/question-mark.html
+[Module system path changes]: 2018/transitioning/modules/path-clarity.html
 [issue#44660]: https://github.com/rust-lang/rust/issues/44660
-[Import macros via `use`]: https://rust-lang-nursery.github.io/edition-guide/2018/transitioning/modules/macros.html
+[Import macros via `use`]: 2018/transitioning/modules/macros.html
 [issue#35896]: https://github.com/rust-lang/rust/issues/35896
-[In-band lifetimes]: https://rust-lang-nursery.github.io/edition-guide/2018/transitioning/ownership-and-lifetimes/in-band-lifetimes.html
+[In-band lifetimes]: 2018/transitioning/ownership-and-lifetimes/in-band-lifetimes.html
 [issue#44524]: https://github.com/rust-lang/rust/issues/44524
-[Lifetime elision in `impl`s]: https://rust-lang-nursery.github.io/edition-guide/2018/transitioning/ownership-and-lifetimes/lifetime-elision-in-impl.html
-[Raw identifiers]: https://rust-lang-nursery.github.io/edition-guide/2018/transitioning/raw-identifiers.html
+[Lifetime elision in `impl`s]: 2018/transitioning/ownership-and-lifetimes/lifetime-elision-in-impl.html
+[Raw identifiers]: 2018/transitioning/raw-identifiers.html
 [issue#48589]: https://github.com/rust-lang/rust/issues/48589
 [nll_status]: http://smallcultfollowing.com/babysteps/blog/2018/06/15/mir-based-borrow-check-nll-status-update/
-[`T: 'a` inference in `struct`s]: https://rust-lang-nursery.github.io/edition-guide/2018/transitioning/ownership-and-lifetimes/struct-inference.html
+[`T: 'a` inference in `struct`s]: 2018/transitioning/ownership-and-lifetimes/struct-inference.html
 [issue#44493]: https://github.com/rust-lang/rust/issues/44493
-[`async`/`await`]: https://rust-lang-nursery.github.io/edition-guide/2018/transitioning/concurrency/async-await.html
+[`async`/`await`]: 2018/transitioning/concurrency/async-await.html
 [issue#50547]: https://github.com/rust-lang/rust/issues/50547
 
 | **Feature** | **Status** | **Minimum Edition** |

--- a/src/2018/transitioning/ownership-and-lifetimes/lifetime-elision-in-impl.md
+++ b/src/2018/transitioning/ownership-and-lifetimes/lifetime-elision-in-impl.md
@@ -2,7 +2,7 @@
 
 When writing an `impl`, you can mention lifetimes without them being bound in
 the argument list. This is similar to
-[in-band-lifetimes](/2018/transitioning/ownership-and-lifetimes/in-band-lifetimes.md)
+[in-band-lifetimes](2018/transitioning/ownership-and-lifetimes/in-band-lifetimes.html)
 but for `impl`s.
 
 In Rust 2015:


### PR DESCRIPTION
The first commit fixes a broken link.  (The broken link is found in the first paragraph of [this page](https://rust-lang-nursery.github.io/edition-guide/2018/transitioning/ownership-and-lifetimes/lifetime-elision-in-impl.html))

The second commit converts intra-book links to relative links.  This makes is easier to preview the book on a locally hosted build.