### PR TITLE
Added note about 2015 features in the feature status table

### DIFF
--- a/src/2018/status.md
+++ b/src/2018/status.md
@@ -45,6 +45,11 @@
 | [Module system path changes] | Unstable; [tracking issue][issue#44660] | 2018 |
 | [`async`/`await`] | [Not fully implemented][issue#50547] | 2018 |
 
+While some of these features are already available in Rust 2015, they are tracked here
+because they are being promoted as part of the Rust 2018 edition.  Accordingly, they
+will be discussed in subsequent sections of this guide book. The features marked as
+"Shipped" are all available today in stable Rust, so you can start using them right now!
+
 ## Standard library
 
 [issue#49668]: https://github.com/rust-lang/rust/issues/49668


### PR DESCRIPTION
This change falls out of some of the discussion in #63.  I don't feel particularly strongly about this change, but I do think it helps provide some useful context for this table.