### PR TITLE
Fix broken link in impl Trait page

### DIFF
--- a/src/2018/transitioning/traits/impl-trait.md
+++ b/src/2018/transitioning/traits/impl-trait.md
@@ -83,7 +83,7 @@ we still can obscure the `i32` return type.
 With `i32`, this isn't super useful. But there's one major place in Rust
 where this is much more useful: closures.
 
-[`dyn Trait`]: /2018/transitioning/traits/dyn-trait.html
+[`dyn Trait`]: 2018/transitioning/traits/dyn-trait.html
 
 ### `impl Trait` and closures
 


### PR DESCRIPTION
The broken link is visible in the second text paragraph of the "Return Position" section of the "impl Trait" page: https://rust-lang-nursery.github.io/edition-guide/2018/transitioning/traits/impl-trait.html#return-position
