### PR TITLE
Explicitly mention not passing prepare flag after switching to new edition

### DIFF
--- a/src/editions/transitioning.md
+++ b/src/editions/transitioning.md
@@ -91,10 +91,6 @@ build`. If it does not, this is a bug! Please [file an issue][issue].
 
 [issue]: https://github.com/rust-lang/rust/issues/new
 
-Now that you've switched to the new edition, you should no longer pass the
-`--prepare-for 2018` flag to `cargo fix` because you are now already on
-the next edition!
-
 ## Writing idiomatic code in a new edition
 
 Your crate has now entered the 2018 edition of Rust, congrats! Recall though
@@ -109,7 +105,9 @@ these lints add this to your `lib.rs` or `main.rs`:
 #![warn(rust_2018_idioms)]
 ```
 
-and then execute:
+Note that since you already switched to the new edition in the previous section,
+you should no longer pass the `--prepare-for 2018` flag to `cargo fix` because
+you are now already on the next edition! Execute:
 
 ```shell
 $ cargo +nightly fix

--- a/src/editions/transitioning.md
+++ b/src/editions/transitioning.md
@@ -91,6 +91,10 @@ build`. If it does not, this is a bug! Please [file an issue][issue].
 
 [issue]: https://github.com/rust-lang/rust/issues/new
 
+Now that you've switched to the new edition, you should no longer pass the
+`--prepare-for 2018` flag to `cargo fix` because you are now already on
+the next edition!
+
 ## Writing idiomatic code in a new edition
 
 Your crate has now entered the 2018 edition of Rust, congrats! Recall though


### PR DESCRIPTION
Related to https://github.com/rust-lang/cargo/issues/5778.

Based on feedback from the [internals thread](https://internals.rust-lang.org/t/help-test-out-the-2018-module-system-changes/8047/20?u=johnthagen), hopefully this clarification will help people realize not to pass the `--prepare-for` flag after they've already transitioned to the new edition.

Hopefully removes a paper cut when others test out this feature.