### PR TITLE
fix #29 (async await listed as both available and not available).

### DIFF
--- a/src/2018/status.md
+++ b/src/2018/status.md
@@ -24,8 +24,6 @@
 [nll_status]: http://smallcultfollowing.com/babysteps/blog/2018/06/15/mir-based-borrow-check-nll-status-update/
 [`T: 'a` inference in `struct`s]: transitioning/ownership-and-lifetimes/struct-inference.html
 [issue#44493]: https://github.com/rust-lang/rust/issues/44493
-[`async`/`await`]: transitioning/concurrency/async-await.html
-[issue#50547]: https://github.com/rust-lang/rust/issues/50547
 
 | **Feature** | **Status** | **Minimum Edition** |
 | ----------- | ---------- | -------------------------- |
@@ -43,7 +41,6 @@
 | [Raw identifiers] | Unstable; [tracking issue][issue#48589] | ? |
 | [Import macros via `use`] | Unstable; [tracking issue][issue#35896] | ? |
 | [Module system path changes] | Unstable; [tracking issue][issue#44660] | 2018 |
-| [`async`/`await`] | [Not fully implemented][issue#50547] | 2018 |
 
 While some of these features are already available in Rust 2015, they are tracked here
 because they are being promoted as part of the Rust 2018 edition.  Accordingly, they

--- a/src/2018/transitioning/concurrency/async-await.md
+++ b/src/2018/transitioning/concurrency/async-await.md
@@ -1,7 +1,17 @@
-# async/await
+# `async` and `await`
 
-Async/await has not been implemented in the compiler yet.
+You can try out the `async` / `await` feature on a nightly compiler:
+
+```rust,ignore
+#![feature(async_await, futures_api)]
+
+async fn foo(x: &usize) -> usize {
+    x + 1
+}
+```
 
 ## More details
 
-Coming soon!
+Note that `async` and `await` will not be stable in the initial release of
+Rust 2018. See the [tracking issue](https://github.com/rust-lang/rust/issues/50547)
+for more information.

--- a/src/2018/transitioning/concurrency/index.md
+++ b/src/2018/transitioning/concurrency/index.md
@@ -1,6 +1,10 @@
 # Concurrency additions
 
-While concurrency and parallelism has always been a strong suit of Rust, it
-often requires a lot of boilerplate. In Rust 2018, two new keywords, `async`
-and `await`, help you write code that appears sequential, but executes
-concurrently.
+While concurrency and parallelism has always been a strong suit of Rust,
+it often requires a lot of boilerplate. In Rust 2018, two new keywords,
+`async` and `await`, help you write code that appears sequential,
+but executes concurrently.
+
+Note that `async` and `await` will not be stable in the initial release of
+Rust 2018. See the [tracking issue](https://github.com/rust-lang/rust/issues/50547)
+for more information.

--- a/src/editions/transitioning.md
+++ b/src/editions/transitioning.md
@@ -2,11 +2,11 @@
 
 New editions might change the way you write Rust -- they add new syntax,
 language, and library features but also remove features. For example,
-`async`/`await` are keywords in Rust 2018, but not Rust 2015. Despite this
-it's our intention that the migration to new editions is as smooth an experience
-as possible. It's considered a bug if it's difficult to upgrade your crate to a
-new edition. If you have a difficult time then a bug should be filed with Rust
-itself.
+`try`, `async`, and `await` are keywords in Rust 2018, but not Rust 2015.
+Despite this it's our intention that the migration to new editions is as
+smooth an experience as possible. It's considered a bug if it's difficult to
+upgrade your crate to a new edition. If you have a difficult time then a bug
+should be filed with Rust itself.
 
 Transitioning between editions is built around compiler lints. Fundamentally,
 the process works like this:


### PR DESCRIPTION
This PR should fix #29.

It does not remove the concurrency chapter (https://rust-lang-nursery.github.io/edition-guide/2018/transitioning/concurrency/index.html) but does update things to reflect reality and notes that async / await won't ship with the release of Rust 2018.

Maybe we should remove that chapter as well...?