### PR TITLE
It is safe to write to a union field

### DIFF
--- a/src/rust-2018/data-types/union-for-an-unsafe-form-of-enum.md
+++ b/src/rust-2018/data-types/union-for-an-unsafe-form-of-enum.md
@@ -16,8 +16,7 @@ that stores which variant is the correct one at runtime; unions don't have
 this tag.
 
 Since we can interpret the data held in the union using the wrong variant and
-Rust can’t check this for us, that means reading or writing a union’s field
-is unsafe:
+Rust can’t check this for us, that means reading a union’s field is unsafe:
 
 ```rust
 # union MyUnion {
@@ -26,7 +25,7 @@ is unsafe:
 # }
 let mut u = MyUnion { f1: 1 };
 
-unsafe { u.f1 = 5 };
+u.f1 = 5;
 
 let value = unsafe { u.f1 };
 ```


### PR DESCRIPTION
[/src/rust-2018/data-types/union-for-an-unsafe-form-of-enum.md](https://github.com/rust-lang-nursery/edition-guide/blob/7c18f376e9de562c28f46c02f3afe3b4941ff6c2/src/rust-2018/data-types/union-for-an-unsafe-form-of-enum.md)

> ..., that means reading or writing a union’s field is unsafe:

```rust
let mut u = MyUnion { f1: 1 };

unsafe { u.f1 = 5 };

let value = unsafe { u.f1 };
```

Writing to a union field is actually safe. The above code snippet produces a compiler warning.

```
warning: unnecessary `unsafe` block
 --> src/main.rs:9:5
  |
9 |     unsafe { u.f1 = 5 };
  |     ^^^^^^ unnecessary `unsafe` block
  |
  = note: #[warn(unused_unsafe)] on by default
```

This pull request removes the `unsafe` block from the snippet as well as tweaking the text.

* * *

Note:
```
$ rustc -V
rustc 1.28.0 (9634041f0 2018-07-30)
```