### PR TITLE
Clearer documentation for "No more mod.rs"

### DIFF
--- a/src/rust-2018/module-system/path-clarity.md
+++ b/src/rust-2018/module-system/path-clarity.md
@@ -223,7 +223,6 @@ It can live in `foo.rs` or `foo/mod.rs`. If it has submodules of its own, it
 *must* be `foo/mod.rs`. So a `bar` submodule of `foo` would live at
 `foo/bar.rs`.
 
-
 In Rust 2018, `mod.rs` is no longer needed. 
 
 ```rust,ignore
@@ -240,8 +239,6 @@ mod bar;
 and the submodule is still `foo/bar.rs`. This eliminates the special
 name, and if you have a bunch of files open in your editor, you can clearly
 see their names, instead of having a bunch of tabs named `mod.rs`.
-
-
 
 # Uniform paths
 

--- a/src/rust-2018/module-system/path-clarity.md
+++ b/src/rust-2018/module-system/path-clarity.md
@@ -212,6 +212,10 @@ Much more straightforward.
 In Rust 2015, if you have a submodule:
 
 ```rust,ignore
+///  foo.rs 
+///  or 
+///  foo/mod.rs
+
 mod foo;
 ```
 
@@ -219,10 +223,25 @@ It can live in `foo.rs` or `foo/mod.rs`. If it has submodules of its own, it
 *must* be `foo/mod.rs`. So a `bar` submodule of `foo` would live at
 `foo/bar.rs`.
 
-In Rust 2018, `mod.rs` is no longer needed. `foo.rs` can just be `foo.rs`,
+
+In Rust 2018, `mod.rs` is no longer needed. 
+
+```rust,ignore
+///  foo.rs 
+///  foo/bar.rs
+
+mod foo;
+
+/// in foo.rs
+mod bar;
+```
+
+`foo.rs` can just be `foo.rs`,
 and the submodule is still `foo/bar.rs`. This eliminates the special
 name, and if you have a bunch of files open in your editor, you can clearly
 see their names, instead of having a bunch of tabs named `mod.rs`.
+
+
 
 # Uniform paths
 


### PR DESCRIPTION
### No more `mod.rs`

In Rust 2015, if you have a submodule:

```rust,ignore
///  foo.rs 
///  or 
///  foo/mod.rs

mod foo;
```

It can live in `foo.rs` or `foo/mod.rs`. If it has submodules of its own, it
*must* be `foo/mod.rs`. So a `bar` submodule of `foo` would live at
`foo/bar.rs`.


In Rust 2018, `mod.rs` is no longer needed. 

```rust,ignore
///  foo.rs 
///  foo/bar.rs

mod foo;

/// in foo.rs
mod bar;
```

`foo.rs` can just be `foo.rs`,
and the submodule is still `foo/bar.rs`. This eliminates the special
name, and if you have a bunch of files open in your editor, you can clearly
see their names, instead of having a bunch of tabs named `mod.rs`.