### PR TITLE
Fix extern crate alias example for anchored paths

### DIFF
--- a/src/rust-2018/module-system/path-clarity.md
+++ b/src/rust-2018/module-system/path-clarity.md
@@ -82,7 +82,7 @@ then removing the `extern crate` line on its own won't work. You'll need to do t
 ```rust,ignore
 use futures as f;
 
-use f::Future;
+use self::f::Future;
 ```
 
 This change will need to happen in any module that uses `f`.


### PR DESCRIPTION
Most of the page but the last section describes anchored paths.
The original example works for uniform paths which are described only at the bottom of the page as a possible alternative to anchored paths -- https://github.com/rust-lang/rust/issues/53130#issuecomment-418824862 indicates that anchored paths may be chosen, at least for now, while leaving the door open for uniform paths.