### PR TITLE
Mark impl-header-lifetime-elision as 1.31 instead of beta

### DIFF
--- a/src/rust-2018/ownership-and-lifetimes/lifetime-elision-in-impl.md
+++ b/src/rust-2018/ownership-and-lifetimes/lifetime-elision-in-impl.md
@@ -1,6 +1,6 @@
 # Lifetime elision in impl
 
-![Minimum Rust version: beta](https://img.shields.io/badge/Minimum%20Rust%20Version-beta-orange.svg)
+![Minimum Rust version: 1.31](https://img.shields.io/badge/Minimum%20Rust%20Version-1.31-brightgreen.svg)
 
 When writing `impl` blocks, you can now elide lifetime annotations in some
 situations.


### PR DESCRIPTION
Now that https://github.com/rust-lang/rust/pull/54778 is in.

(I don't know when this should be committed, but I figured I'd post the PR regardless.)