### PR TITLE
Fix failing tidy (line endings on Windows)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto eol=lf


### PR DESCRIPTION
This happens every time a new doc submodule is added to https://github.com/rust-lang/rust.
cc https://github.com/rust-lang/book/pull/549 https://github.com/rust-lang-nursery/reference/pull/36 https://github.com/rust-lang/rust-by-example/pull/1018 https://github.com/rust-lang/rustc-guide/pull/246