### PR TITLE
aborting-on-panic.md: Typo in example config

### DIFF
--- a/src/rust-2018/error-handling-and-panics/aborting-on-panic.md
+++ b/src/rust-2018/error-handling-and-panics/aborting-on-panic.md
@@ -6,7 +6,7 @@ By default, Rust programs will unwind the stack when a `panic!` happens. If you'
 immediate abort instead, you can configure this in `Cargo.toml`:
 
 ```toml
-[profile.debug]
+[profile.dev]
 panic = "abort"
 
 [profile.release]


### PR DESCRIPTION
When trying to use the provided config, cargo warns:

```
warning: unused manifest key: profile.debug
warning: use `[profile.dev]` to configure debug builds
```