### PR TITLE
rust-2018/control-flow/index: Fix link

### DIFF
--- a/src/rust-2018/control-flow/index.md
+++ b/src/rust-2018/control-flow/index.md
@@ -1,6 +1,6 @@
 # Control flow
 
-[async_await]: rust-2018/control-flow/async-await-for-easier-concurrency.html
+[async_await]: async-await-for-easier-concurrency.html
 
 In this chapter of the guide, we discuss a few improvements to control flow.
 The most notable of these *will* be [`async` and `await`][async_await].


### PR DESCRIPTION
The link in <https://rust-lang-nursery.github.io/edition-guide/rust-2018/control-flow/index.html> points to <https://rust-lang-nursery.github.io/edition-guide/rust-2018/control-flow/rust-2018/control-flow/async-await-for-easier-concurrency.html>, as the destination is relative, but the path is from the root. Remove the non-relative part of the path to fix the link.