### PR TITLE
Add minimum Rust version for Kleene operator

### DIFF
--- a/src/rust-2018/macros/at-most-once.md
+++ b/src/rust-2018/macros/at-most-once.md
@@ -1,5 +1,7 @@
 # At most one repetition
 
+![Minimum Rust version: 1.32](https://img.shields.io/badge/Minimum%20Rust%20Version-1.32-brightgreen.svg)
+
 In Rust 2018, we have made a couple of changes to the macros-by-example syntax.
 
 1. We have added a new Kleene operator `?` which means "at most one"


### PR DESCRIPTION
The [release notes for 1.32.0](https://github.com/rust-lang/rust/blob/stable/RELEASES.md#version-1320-2019-01-17) confirm that the `?` Kleene operator was only just added in `1.32.0`, and was not supposed to be part of `1.31.0` ("Rust 2018"). This adds a minimum Rust version badge to that section.

Closes #128.