### PR TITLE
Update for anonymous-lifetime stabilization.

### DIFF
--- a/src/rust-2018/ownership-and-lifetimes/the-anonymous-lifetime.md
+++ b/src/rust-2018/ownership-and-lifetimes/the-anonymous-lifetime.md
@@ -1,6 +1,6 @@
 # `'_`, the anonymous lifetime
 
-![Minimum Rust version: nightly](https://img.shields.io/badge/Minimum%20Rust%20Version-nightly-red.svg)
+![Minimum Rust version: 1.31](https://img.shields.io/badge/Minimum%20Rust%20Version-1.31-brightgreen.svg)
 
 Rust 2018 allows you to explicitly mark where a lifetime is elided, for types
 where this elision might otherwise be unclear. To do this, you can use the
@@ -36,8 +36,6 @@ impl<'a> fmt::Debug for StrWrap<'a> {
 In Rust 2018, you can instead write:
 
 ```rust
-#![feature(rust_2018_preview)]
-
 # use std::fmt;
 # struct StrWrap<'a>(&'a str);
 
@@ -84,8 +82,6 @@ impl<'a, 'b: 'a> Foo<'a, 'b> {
 We can rewrite this as:
 
 ```rust
-#![feature(rust_2018_preview)]
-
 # struct Foo<'a, 'b: 'a> {
 #     field: &'a &'b str,
 # }


### PR DESCRIPTION
I think this is what was stabilized in 1.31.  It's not really clear to me what is left to be done (why the tracing issue is still open).  There's also `impl_header_lifetime_elision` which I [can't quite figure out](https://github.com/rust-lang-nursery/reference/issues/479).