### PR TITLE
Fix issue with rust's linkchecker and mdbook.

### DIFF
--- a/src/rust-2018/edition-changes.md
+++ b/src/rust-2018/edition-changes.md
@@ -3,7 +3,6 @@
 The following is a summary of changes that only apply to code compiled with
 the 2018 edition compared to the 2015 edition.
 
-## Rust
 - [Non-lexical lifetimes]&nbsp;(future inclusion planned for 2015 edition)
 - [At most once] `?` macro repetition operator.
 - [Path changes]:


### PR DESCRIPTION
The linkchecker in the rust repo rejects this because there are duplicate
HTML id's. The theme selector uses the id "rust" for the Rust color theme.
See https://github.com/rust-lang-nursery/mdBook/issues/880 for more info.

This blocks updating upstream.
