### PR TITLE
Migrate to mdbook 0.2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You can also build the book and read it locally if you'd like.
 
 ### Requirements
 
-Building the book requires [mdBook]. To get it:
+Building the book requires [mdBook] 0.2. To get it:
 
 [mdBook]: https://github.com/azerupi/mdBook
 

--- a/src/editions/transitioning-an-existing-project-to-a-new-edition.md
+++ b/src/editions/transitioning-an-existing-project-to-a-new-edition.md
@@ -21,7 +21,7 @@ trait Foo {
 ```
 
 This code uses an anonymous parameter, that `Box<Foo>`. This is [not
-supported in Rust 2018](rust-2018/trait-system/no-anon-params.html), and
+supported in Rust 2018](../rust-2018/trait-system/no-anon-params.md), and
 so this would fail to compile. Let's get this code up to date!
 
 ## Updating your code to be compatible with the new edition
@@ -89,7 +89,7 @@ trait Foo {
 ```
 
 In Rust 2018, it's considered idiomatic to use the [`dyn`
-keyword](rust-2018/trait-system/dyn-trait-for-trait-objects.html) for
+keyword](../rust-2018/trait-system/dyn-trait-for-trait-objects.md) for
 trait objects.
 
 Eventually, we want `cargo fix` to fix all these idioms automatically in the same

--- a/src/rust-2018/cargo-and-crates-io/index.md
+++ b/src/rust-2018/cargo-and-crates-io/index.md
@@ -1,6 +1,6 @@
 # Cargo and crates.io
 
-[check]: rust-2018/cargo-and-crates-io/cargo-check-for-faster-checking.html
+[check]: cargo-check-for-faster-checking.md
 
 In this chapter of the guide, we discuss a few improvements to `cargo` and crates.io.
 A notable addition here is the new [`cargo check`][check] command.

--- a/src/rust-2018/control-flow/index.md
+++ b/src/rust-2018/control-flow/index.md
@@ -1,6 +1,6 @@
 # Control flow
 
-[async_await]: rust-2018/control-flow/async-await-for-easier-concurrency.html
+[async_await]: async-await-for-easier-concurrency.md
 
 In this chapter of the guide, we discuss a few improvements to control flow.
 The most notable of these *will* be [`async` and `await`][async_await].

--- a/src/rust-2018/data-types/index.md
+++ b/src/rust-2018/data-types/index.md
@@ -1,6 +1,6 @@
 # Data types
 
-[fis]: rust-2018/data-types/field-init-shorthand.html
+[fis]: field-init-shorthand.md
 
 In this chapter of the guide, we discuss a few improvements to data types.
 One of these are [field-init-shorthand][fis].

--- a/src/rust-2018/documentation/index.md
+++ b/src/rust-2018/documentation/index.md
@@ -1,6 +1,6 @@
 # Documentation
 
-[sec_ed]: rust-2018/documentation/new-editions-of-the-book.html
+[sec_ed]: new-editions-of-the-book.md
 
 In this chapter of the guide, we discuss a few improvements to documentation.
 A notable addition here is the [second edition of "the book"][sec_ed].

--- a/src/rust-2018/edition-changes.md
+++ b/src/rust-2018/edition-changes.md
@@ -27,12 +27,12 @@ the 2018 edition compared to the 2015 edition.
 - `cargo install` for the current directory is no longer allowed, you must
   specify `cargo install --path .` to install the current package.
 
-[Anonymous trait function parameters]: rust-2018/trait-system/no-anon-params.html
-[At most once]: rust-2018/macros/at-most-once.html
-[Non-lexical lifetimes]: rust-2018/ownership-and-lifetimes/non-lexical-lifetimes.html
-[Path changes]: rust-2018/module-system/path-clarity.html
+[Anonymous trait function parameters]: trait-system/no-anon-params.md
+[At most once]: macros/at-most-once.md
+[Non-lexical lifetimes]: ownership-and-lifetimes/non-lexical-lifetimes.md
+[Path changes]: module-system/path-clarity.md
 [Trait function parameters]: https://doc.rust-lang.org/stable/reference/items/traits.html#parameter-patterns
-[`dyn`]: rust-2018/trait-system/dyn-trait-for-trait-objects.html
+[`dyn`]: trait-system/dyn-trait-for-trait-objects.md
 [reserved keywords]: https://doc.rust-lang.org/reference/keywords.html#reserved-keywords
 [strict keyword]: https://doc.rust-lang.org/reference/keywords.html#strict-keywords
 [tyvar_behind_raw_pointer]: https://github.com/rust-lang/rust/issues/46906

--- a/src/rust-2018/error-handling-and-panics/index.md
+++ b/src/rust-2018/error-handling-and-panics/index.md
@@ -1,6 +1,6 @@
 # Error handling and Panics
 
-[qop]: rust-2018/error-handling-and-panics/the-question-mark-operator-for-easier-error-handling.html
+[qop]: the-question-mark-operator-for-easier-error-handling.md
 
 In this chapter of the guide, we discuss a few improvements to error handling
 in Rust. The most notable of these is [the introduction of the `?` operator][qop].

--- a/src/rust-2018/macros/index.md
+++ b/src/rust-2018/macros/index.md
@@ -1,6 +1,6 @@
 # Macros
 
-[custom-derive]: rust-2018/macros/custom-derive.html
+[custom-derive]: custom-derive.md
 
 In this chapter of the guide, we discuss a few improvements to the macro system.
 A notable addition here is the introduction of [custom derive macros][custom-derive].

--- a/src/rust-2018/module-system/index.md
+++ b/src/rust-2018/module-system/index.md
@@ -1,6 +1,6 @@
 # Module system
 
-[path clarity changes]: rust-2018/module-system/path-clarity.html
+[path clarity changes]: path-clarity.md
 
 In this chapter of the guide, we discuss a few changes to the module system.
 The most notable of these are the [path clarity changes].

--- a/src/rust-2018/module-system/path-clarity.md
+++ b/src/rust-2018/module-system/path-clarity.md
@@ -89,7 +89,7 @@ Finally, on nightly, you'll need it for crates like:
 #### Macros
 
 One other use for `extern crate` was to import macros; that's no longer needed.
-Check [the macro section](rust-2018/macros/macro-changes.html) for more.
+Check [the macro section](../macros/macro-changes.md) for more.
 
 If you've been using `as` to rename your crate like this:
 

--- a/src/rust-2018/ownership-and-lifetimes/index.md
+++ b/src/rust-2018/ownership-and-lifetimes/index.md
@@ -1,6 +1,6 @@
 # Ownership and lifetimes
 
-[dmbm]: rust-2018/ownership-and-lifetimes/default-match-bindings.html
+[dmbm]: default-match-bindings.md
 
 In this chapter of the guide, we discuss a few improvements to ownership and lifetimes.
 One of the most notable of these is [default match binding modes][dmbm].

--- a/src/rust-2018/ownership-and-lifetimes/lifetime-elision-in-impl.md
+++ b/src/rust-2018/ownership-and-lifetimes/lifetime-elision-in-impl.md
@@ -72,4 +72,4 @@ impl<T> Drop for SetOnDrop<'_, T> {
 }
 ```
 
-[the anonymous lifetime]: rust-2018/ownership-and-lifetimes/the-anonymous-lifetime.html
+[the anonymous lifetime]: the-anonymous-lifetime.md

--- a/src/rust-2018/platform-and-target-support/index.md
+++ b/src/rust-2018/platform-and-target-support/index.md
@@ -1,6 +1,6 @@
 # Platform and target support
 
-[libcore]: rust-2018/platform-and-target-support/libcore-for-low-level-rust.html
+[libcore]: libcore-for-low-level-rust.md
 
 In this chapter of the guide, we discuss a few improvements to platform and target support.
 A notable addition to it was [that the `libcore` library now works on stable Rust][libcore].

--- a/src/rust-2018/rustdoc/index.md
+++ b/src/rust-2018/rustdoc/index.md
@@ -1,6 +1,6 @@
 # `rustdoc`
 
-[cf]: rust-2018/rustdoc/documentation-tests-can-now-compile-fail.html
+[cf]: documentation-tests-can-now-compile-fail.md
 
 In this chapter of the guide, we discuss a few improvements to `rustdoc`.
 A notable addition to it was [that documentation tests can now compile-fail][cf].

--- a/src/rust-2018/the-compiler/index.md
+++ b/src/rust-2018/the-compiler/index.md
@@ -1,6 +1,6 @@
 # The compiler
 
-[errors]: rust-2018/the-compiler/improved-error-messages.html
+[errors]: improved-error-messages.md
 
 In this chapter of the guide, we discuss a few improvements to the compiler.
 A notable addition here is our new and [improved error messages][errors].

--- a/src/rust-2018/trait-system/dyn-trait-for-trait-objects.md
+++ b/src/rust-2018/trait-system/dyn-trait-for-trait-objects.md
@@ -36,7 +36,7 @@ is sometimes slower, and often cannot be used at all when its alternatives can.
 
 Furthermore, with `impl Trait` arriving, "`impl Trait` vs `dyn Trait`" is much
 more symmetric, and therefore a bit nicer, than "`impl Trait` vs `Trait`".
-`impl Trait` is explained [here](rust-2018/trait-system/impl-trait-for-returning-complex-types-with-ease.html)
+`impl Trait` is explained [here](impl-trait-for-returning-complex-types-with-ease.md)
 
 In the new edition, you should therefore prefer `dyn Trait` to just `Trait`
 where you need a trait object.

--- a/src/rust-2018/trait-system/index.md
+++ b/src/rust-2018/trait-system/index.md
@@ -1,6 +1,6 @@
 # Trait system
 
-[impl_trait]: rust-2018/trait-system/impl-trait-for-returning-complex-types-with-ease.html
+[impl_trait]: impl-trait-for-returning-complex-types-with-ease.md
 
 In this chapter of the guide, we discuss a few improvements to the trait system.
 The most notable of these is [`impl Trait`][impl_trait].


### PR DESCRIPTION
Now that rust-lang/rust supports mdbook 0.2, migrate to it.
This is the result of running the script
https://gist.github.com/ehuss/b2a647eb69aa8f57bc4fb397656dfac1

I have tested in-repo with linkchecker, and it seems to be ok. I can handle
updating the submodule once this is merged.