### PR TITLE
Fix typo in controlling-panics-with-std-panic.md

### DIFF
--- a/src/rust-2018/error-handling-and-panics/controlling-panics-with-std-panic.md
+++ b/src/rust-2018/error-handling-and-panics/controlling-panics-with-std-panic.md
@@ -49,7 +49,7 @@ and so catching panics may not work. If your code relies on `catch_unwind`, you
 should add this to your Cargo.toml:
 
 ```toml
-[profile.debug]
+[profile.dev]
 panic = "unwind"
 
 [profile.release]


### PR DESCRIPTION
I copied the example and was hit with a compiler warning.